### PR TITLE
args galore

### DIFF
--- a/flicker_ender.lua
+++ b/flicker_ender.lua
@@ -313,6 +313,9 @@ local function drawPlayerSprites(forward)
         start, stop, step = 1, 16, 1
     else
         start, stop, step = 16, 1, -1
+        if args.order == "recommended" then
+            stop = 2
+        end
     end
     
     for i = start, stop, step do
@@ -412,6 +415,9 @@ local function drawSpritesNormal()
         end
     else
          -- Draw sprites backwards
+         if args.order == "recommended" then
+            drawPlayerSprite(0) -- always draw Mega Man on top
+         end
          for i = #drawFuncs, 1, -1 do
             drawFuncs[i](false)
          end

--- a/flicker_ender.lua
+++ b/flicker_ender.lua
@@ -358,6 +358,7 @@ end
 
 local shuffler = 0
 
+-- This is how the game Recca does it.
 local function drawSpritesReccaStyle()
 
     local frameCount = memory.readbyte(0x1C)
@@ -381,6 +382,7 @@ local function drawSpritesReccaStyle()
         drawEnergyBars()
     end
     
+    -- Incrementing by anything less than 4 (or by a number that doesn't divide 16) is a bit of an eyesore.
     shuffler = (shuffler + 4) % 0x10
     
 end
@@ -402,6 +404,10 @@ local function drawSpritesNormal()
     -- go away!
     if not debugMode and not taseditor.engaged() then emu.setrenderplanes(false, true) end
     
+    -- Alternating shuffle will make two or three things flicker on and off when you start to go over.
+    -- It's good when you're a bit over the limit.
+    -- Cyclic shuffle will give everything its turn flicked off.
+    -- It's good when you're WAY over the limit.
     if args.shuffle == "cyclic" then
         drawSpritesReccaStyle()
         return

--- a/flicker_ender.lua
+++ b/flicker_ender.lua
@@ -64,8 +64,6 @@ if args.oam_limit then
     tdraw.setOamLimit(args.oam_limit)
 end
 
--- TODO: no draw and re enable sprites when panning backwards
--- turn sprites back on on exit
 if args.verbose >= 1 then print(string.format("shuffle: %s, drawOrder: %s", args.shuffle, drawOrder)) end
 
 -- For Mega Man 2, most of these addresses probably need to be adjusted.
@@ -113,11 +111,11 @@ local function drawEnergyBar(energy, x, palette)
     end
 end
 
--- TODO: Hack repositioning compatibility? Wrong palette?
+-- TODO: Grab X positions and boss palettes from ROM to support changes in hacks
 local function drawEnergyBars()
     
     local health = memory.readbyte(0x06C0)
-    drawEnergyBar(health, 0x18, 1) -- TODO: Grab these X values from ROM to support relocation in hacks
+    drawEnergyBar(health, 0x18, 1)
     
     local equippedWeapon = memory.readbyte(0xA9)
     if equippedWeapon ~= 0 then
@@ -253,8 +251,8 @@ local function drawPlayerSprite(slot)
     end
     
     ptr = getPtr(PLAYER_CEL_PTRS_HI, PLAYER_CEL_PTRS_LO, celId)
-    drawCel(ptr, slot, flags, 0)
     if args.verbose >= 1 then print(string.format("cel ptr: $%04X", ptr)) end
+    drawCel(ptr, slot, flags, 0) -- Are there really no attribute overrides for player sprites?
     
 end
 

--- a/flicker_ender.lua
+++ b/flicker_ender.lua
@@ -227,9 +227,14 @@ local function drawPlayerSprite(slot)
         -- Mega Man
         local iFrames = memory.readbyte(0x4B)
         if iFrames ~= 0 then
-            -- Flicker Mega Man on and off every 2 frames
             local frameCount = memory.readbyte(0x1C)
-            if not args.disable_i_frame_flicker and bit.band(frameCount, 2) ~= 0 then
+            if args.disable_i_frame_flicker then
+                -- The knockback animation has a crash star as one of its cels. To disable this, just set it back to the regular knockback pose.
+                if celId == 0x18 then
+                    celId = 0x7
+                end
+            elseif bit.band(frameCount, 2) ~= 0 then
+                -- Flicker Mega Man on and off every 2 frames
                 return
             end
         end
@@ -242,10 +247,10 @@ local function drawPlayerSprite(slot)
         -- Boss
         local iFrames = memory.readbyte(0x05A8)
         if iFrames ~= 0 then
-            -- Flicker boss on and off every 2 frames
             local frameCount = memory.readbyte(0x1C)
-            if not args.disable_i_frame_flicker and bit.band(frameCount, 2) == 0 then -- Double check this logic.
-                celId = 0x18 -- Crash star for blinking invincibility
+            if not args.disable_i_frame_flicker and bit.band(frameCount, 2) == 0 then
+                -- Bosses don't have a knockback animation. Instead, their animation cel is overridden with a crash star 2 out of every 4 frames.
+                celId = 0x18
             end
         end
     end

--- a/flicker_ender.lua
+++ b/flicker_ender.lua
@@ -7,7 +7,7 @@ local parser = argparse()
 -- Let the user pass a permutation? o_o PhE
 parser:option "--order -o"
     :choices {"canonical", "recommended"}
-    :description "Sprite drawing order"
+    :description "Sprite drawing order. canonical = what the game does. recommended = tweaks to fix certain overlapping issues"
     
 parser:option "--shuffle -s"
     :choices {"alternating", "cyclic", "none"}
@@ -23,7 +23,7 @@ parser:option "--oam-limit -l"
         return n
     end)
     :argname "<num sprites>"
-    :description "Limit for the imitation OAM. 64 is the NES default. Use this if you want to make flicker WORSE!"
+    :description "Limit for the imitation OAM. 64 is the NES default, infinite is the flicker_ender default. Use this if you want to make flicker worse!"
     
 parser:flag "--disable-i-frame-flicker -i"
     :description("Whether Mega Man and bosses should flicker on and off during i-frames")
@@ -31,7 +31,7 @@ parser:flag "--debug -d"
     :description "Enable debug mode. Offset rendering and draw some info to the screen"
 parser:flag "--verbose -v"
     :count "0-3"
-    :description "Enable verbose printing. WARNING: very slow!"
+    :description "Enable verbose printing, up to 3 levels. WARNING: very slow!"
 
 -- Janky custom --help because we want to return from this script, not exit the emulator entirely (which os.exit does for some reason)
 -- Add to ffix?

--- a/flicker_ender.lua
+++ b/flicker_ender.lua
@@ -7,7 +7,7 @@ local parser = argparse()
 -- Let the user pass a permutation? o_o PhE
 parser:option "--order -o"
     :choices {"canonical", "recommended"}
-    :description "Sprite drawing order. canonical = what the game does. recommended = tweaks to fix certain overlapping issues"
+    :description "Sprite drawing order. canonical = what the game does. recommended = tweaks to fix certain overlapping issues. If unspecified, will be chosen based on shuffle."
     
 parser:option "--shuffle -s"
     :choices {"alternating", "cyclic", "none"}
@@ -23,10 +23,10 @@ parser:option "--oam-limit -l"
         return n
     end)
     :argname "<num sprites>"
-    :description "Limit for the imitation OAM. 64 is the NES default, infinite is the flicker_ender default. Use this if you want to make flicker worse!"
+    :description "Limit for the imitation OAM. Will be infinite if unspecified (recommended). 64 is the NES default. Use this if you want to make flicker worse!"
     
 parser:flag "--disable-i-frame-flicker -i"
-    :description("Whether Mega Man and bosses should flicker on and off during i-frames")
+    :description("Whether Mega Man and bosses should flicker during i-frames")
 parser:flag "--debug -d"
     :description "Enable debug mode. Offset rendering and draw some info to the screen"
 parser:flag "--verbose -v"

--- a/flicker_ender.lua
+++ b/flicker_ender.lua
@@ -319,6 +319,9 @@ local function drawPlayerSprites(forward)
     else
         start, stop, step = 16, 1, -1
         if args.order == "recommended" then
+            -- Make sure Mega Man and the boss aren't redrawn.
+            -- Relies on specific knowledge of the recommended playerOrder list...
+            start = 15
             stop = 2
         end
     end
@@ -425,13 +428,15 @@ local function drawSpritesNormal()
             func(true)
         end
     else
-         -- Draw sprites backwards
-         if args.order == "recommended" then
-            drawPlayerSprite(0) -- always draw Mega Man on top
-         end
-         for i = #drawFuncs, 1, -1 do
+        -- Draw sprites backwards
+        if args.order == "recommended" then
+           drawPlayerSprite(0) -- always draw Mega Man on top
+           drawPlayerSprite(1) -- Then draw the boss
+           -- The health bar still alternates priority with them, though. Is that a good thing? I can't decide...
+        end
+        for i = #drawFuncs, 1, -1 do
             drawFuncs[i](false)
-         end
+        end
     end
     
 end

--- a/flicker_ender.lua
+++ b/flicker_ender.lua
@@ -275,7 +275,7 @@ local function drawPlayerSprite(slot)
     
     ptr = getPtr(PLAYER_CEL_PTRS_HI, PLAYER_CEL_PTRS_LO, celId)
     if args.verbose >= 1 then print(string.format("cel ptr: $%04X", ptr)) end
-    drawCel(ptr, slot, flags, 0) -- Are there really no attribute overrides for player sprites?
+    drawCel(ptr, slot, flags, 0) -- There are no attribute overrides for player sprites.
     
 end
 
@@ -294,7 +294,7 @@ local function drawEnemySprite(slot)
     
     if args.verbose >= 1 then
         print(string.format("main anim ptr: $%04X", ptr))
-        print(string.format("draw celNum %02X", celId))
+        print(string.format("draw celId %02X", celId))
     end
     
     -- There are some details here in the real code concerning animation timers which we don't care about.

--- a/flicker_ender.lua
+++ b/flicker_ender.lua
@@ -111,10 +111,11 @@ local function drawEnergyBar(energy, x, palette)
     end
 end
 
+-- TODO: Hack repositioning compatibility? Wrong palette?
 local function drawEnergyBars()
     
     local health = memory.readbyte(0x06C0)
-    drawEnergyBar(health, 0x18, 1)
+    drawEnergyBar(health, 0x18, 1) -- TODO: Grab these X values from ROM to support relocation in hacks
     
     local equippedWeapon = memory.readbyte(0xA9)
     if equippedWeapon ~= 0 then
@@ -559,8 +560,8 @@ emu.registerafter(drawSprites)
 registerAddressBanked(0xCC8B, 0xF, normalGfxRoutineCallback)
 registerAddressBanked(0xCD02, 0xF, timeFrozenGfxRoutineCallback)
 registerAddressBanked(0x9396, 0xD, pauseMenuGfxRoutineCallback)
-registerAddressBanked(0x90EF, 0xD, menuInitRoutineCallback) -- This is just the address where it clears OAM. More analysis needed.
-registerAddressBanked(0xD016, 0xF, oamDmaCallback)
+registerAddressBanked(0x90EF, 0xD, menuInitRoutineCallback)
+registerAddressBanked(0xD016, 0xF, oamDmaCallback) -- This is just the address where it clears OAM. More analysis needed.
 
 memory.registerwrite(0x2000, 7, ppuRegCallback)
 

--- a/readme.md
+++ b/readme.md
@@ -9,28 +9,50 @@ Only compatible with **Rockman 2** for now. Not Mega Man 2, not Super Mario Bros
 # Arguments
 
 There are a few arguments you can specify in the script window to tweak the drawing order to your liking.
+By default, this script imitates the alternating drawing order of the game, equivalent to the arguments: `--order canonical --shuffle alternating`
 
 ```
 Usage: flicker_ender.lua [-h] [--order {canonical,recommended}]
-       [--alternating] [--debug] [--verbose]
+       [--shuffle {alternating,cyclic,none}]
+       [--oam-limit <num sprites>] [--disable-i-frame-flicker]
+       [--debug] [--verbose]
 
 Options:
    -h, --help            Show this help message and exit.
    --order {canonical,recommended},
         -o {canonical,recommended}
-                         Sprite drawing order (default: recommended)
-   --alternating, -a     Alternate drawing order every frame
+                         Sprite drawing order. canonical = what the game does. recommended = tweaks to fix certain overlapping issues
+   --shuffle {alternating,cyclic,none},
+          -s {alternating,cyclic,none}
+                         What type of sprite shuffling to use. The real game code uses alternating. (default: alternating)
+   --oam-limit <num sprites>,
+            -l <num sprites>
+                         Limit for the imitation OAM. 64 is the NES default, infinite is the flicker_ender default. Use this if you want to make flicker worse!
+   --disable-i-frame-flicker, -i
+                         Whether Mega Man and bosses should flicker on and off during i-frames
    --debug, -d           Enable debug mode. Offset rendering and draw some info to the screen
-   --verbose, -v         Enable verbose printing. WARNING: very slow!
+   --verbose, -v         Enable verbose printing, up to 3 levels. WARNING: very slow!
 ```
 
 ## Orderings
 
+Really only noticeable if shuffle = none.
+
 - Canonical: The order of objects as laid out in memory. Health bars appear behind everything else.
 - Recommended: A modified drawing order that I think looks best. Health bars appear in front of everything else, and bosses are shifted to draw behind Mega Man's projectiles.
 
-## Alternating
+## Shuffle
 
-The `alternating` flag respects the specfied drawing order and reverses it every frame, in case a set drawing order unnerves you! I recognize that enforcing a set drawing order on a game that does not have one can lead to some visibility issues.  
-Try `--order canonical --alternating` (or `-ao canonical` if you prefer) to get as close to the real game as possible.
+- None: Fixed drawing order. Uses the recommended order by default.
+- Alternating: Reverses the drawing order every frame, in case a set drawing order unnerves you! I recognize that enforcing a set drawing order on a game that does not have one can lead to some visibility issues. Uses canonical order by default.
+- Cyclic: Changes the first sprite drawn each frame, cycling every 4 frames (starts on 0, then 4, 8, 12). Uses canonical order by default.
 
+## OAM Limit
+
+Sets a limit for how many sprites can be drawn each frame. While this may seem antithetical to the purpose of this script, here are the uses cases that motivated its inclusion:
+- You can set it to 64 to play around with different flicker algorithms
+- You can set it to 80 or so if you are experiencing slowdowns from unbounded OAM
+- You can set it to less than 64 for a good laugh
+
+## Disable i-frame flicker
+An enhancement mainly for TASing. It turns off the 2-frame flicker that occurs during invincibility frames so you can better see what you're doing.

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 mm2_flicker_ender reimplements a few of Rockman 2's drawing routines in Lua to overcome the 64-sprite limitation. The goal of this script is to draw the exact tiles the game would have drawn if OAM was infinite.
 
-Only compatible with **Rockman 2** for now. Not Mega Man 2, not Super Mario Bros. 2, not Rockman 3. Just Rockman 2. Mega Man 2 support should eventually be possible. The tiledraw script is more general purpose, and could be reused in a project like this for a different game.
+Only compatible with **Rockman 2** for now. Not Mega Man 2, not Super Mario Bros. 2, not Rockman 3. Just Rockman 2. Mega Man 2 support should eventually be possible. The tiledraw script is more general purpose, and could be reused in a project like this for a [different game](https://www.youtube.com/watch?v=r04V_D3qn2I).
 
 [Video explanation](https://www.youtube.com/watch?v=ua4mlVy9x1Y)
 
@@ -21,15 +21,15 @@ Options:
    -h, --help            Show this help message and exit.
    --order {canonical,recommended},
         -o {canonical,recommended}
-                         Sprite drawing order. canonical = what the game does. recommended = tweaks to fix certain overlapping issues
+                         Sprite drawing order. canonical = what the game does. recommended = tweaks to fix certain overlapping issues. If unspecified, will be chosen based on shuffle.
    --shuffle {alternating,cyclic,none},
           -s {alternating,cyclic,none}
                          What type of sprite shuffling to use. The real game code uses alternating. (default: alternating)
    --oam-limit <num sprites>,
             -l <num sprites>
-                         Limit for the imitation OAM. 64 is the NES default, infinite is the flicker_ender default. Use this if you want to make flicker worse!
+                         Limit for the imitation OAM. Will be infinite if unspecified (recommended). 64 is the NES default. Use this if you want to make flicker worse!
    --disable-i-frame-flicker, -i
-                         Whether Mega Man and bosses should flicker on and off during i-frames
+                         Whether Mega Man and bosses should flicker during i-frames
    --debug, -d           Enable debug mode. Offset rendering and draw some info to the screen
    --verbose, -v         Enable verbose printing, up to 3 levels. WARNING: very slow!
 ```
@@ -55,4 +55,4 @@ Sets a limit for how many sprites can be drawn each frame. While this may seem a
 - You can set it to less than 64 for a good laugh
 
 ## Disable i-frame flicker
-An enhancement mainly for TASing. It turns off the 2-frame flicker that occurs during invincibility frames so you can better see what you're doing.
+An enhancement mainly for TASing. It turns off the 2-frame flicker and crash stars that occur during invincibility frames for Mega Man and bosses so you can better see what you're doing.

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ Really only noticeable if shuffle = none.
 
 - None: Fixed drawing order. Uses the recommended order by default.
 - Alternating: Reverses the drawing order every frame, in case a set drawing order unnerves you! I recognize that enforcing a set drawing order on a game that does not have one can lead to some visibility issues. Uses canonical order by default.
-- Cyclic: Changes the first sprite drawn each frame, cycling every 4 frames (starts on 0, then 4, 8, 12). Uses canonical order by default.
+- Cyclic: Changes the first sprite drawn each frame, cycling every 4 frames (starts on 0, then 4, 8, 12). Always uses canonical order.
 
 ## OAM Limit
 

--- a/tiledraw.lua
+++ b/tiledraw.lua
@@ -189,11 +189,11 @@ end
 
 -- Render to screen what the pretend PPU knows
 function mod.renderBuffer()
-    local offset = debugMode and 10 or 0
+    local offset = debugMode and 32 or 0
     -- Draw in reverse order because that's how the NES priotizes sprites
     for i = math.min(#ppuOam, OAM_LIMIT), 1, -1 do
         local entry = ppuOam[i]
-        mod.drawTile(entry.y + offset, entry.attributes, entry.index, entry.x + offset)
+        mod.drawTile(entry.y, entry.attributes, entry.index, entry.x + offset)
     end
     if debugMode then gui.text(10, 10, #ppuOam, #ppuOam > 64 and "red" or "white") end
     -- if oam is empty, that probably means nothing was drawn and we shouldn't delete it yet.

--- a/tiledraw.lua
+++ b/tiledraw.lua
@@ -126,7 +126,7 @@ end
 -- Draw tile immediately.
 -- Currently only supports 8x8 mode.
 -- Priority bit is based on color rather than opacity of pixel.
--- The back-priority sprite obscurring quirk is not implemented.
+-- The back-priority sprite obscurring quirk is implemented.
 -- Tint bits are not implemented--they actually affect NTSC signal generation, but FCEUX stores them in an extended palette I think.
 -- Are tiles invisible when they should be?
 function mod.drawTile(y, attributes, index, x)
@@ -144,7 +144,7 @@ function mod.drawTile(y, attributes, index, x)
     local flipY = bit.band(attributes, 0x80) ~= 0
     for i = 0, 7 do
         local row = flipY and tileData[7 - i] or tileData[i]
-        drawRow(x, y + 1 + i, row, attributes)
+        drawRow(x, y + 1 + i, row, attributes) -- add 1 to y here because of the whole sprite scanline delay thing
     end
 
 end

--- a/tiledraw.lua
+++ b/tiledraw.lua
@@ -181,7 +181,6 @@ function mod.flushBuffer()
 end
 
 -- With this nonsense in place, you can observe the exact flicker as if you had "Allow more than 8 sprites per scanline" checked.
--- TODO: provide an API to set this
 local OAM_LIMIT = 64000
 
 function mod.setOamLimit(limit)
@@ -192,12 +191,9 @@ end
 function mod.renderBuffer()
     local offset = debugMode and 10 or 0
     -- Draw in reverse order because that's how the NES priotizes sprites
-    local count = 0
-    for i = #ppuOam, 1, -1 do
+    for i = math.min(#ppuOam, OAM_LIMIT), 1, -1 do
         local entry = ppuOam[i]
         mod.drawTile(entry.y + offset, entry.attributes, entry.index, entry.x + offset)
-        count = count + 1
-        if count == OAM_LIMIT then break end
     end
     if debugMode then gui.text(10, 10, #ppuOam, #ppuOam > 64 and "red" or "white") end
     -- if oam is empty, that probably means nothing was drawn and we shouldn't delete it yet.

--- a/tiledraw.lua
+++ b/tiledraw.lua
@@ -181,9 +181,12 @@ function mod.flushBuffer()
 end
 
 -- With this nonsense in place, you can observe the exact flicker as if you had "Allow more than 8 sprites per scanline" checked.
--- Need to make this override canonical order (that's a caller problem, not tiledraw's problem!).
 -- TODO: provide an API to set this
-local OAM_LIMIT = 32000
+local OAM_LIMIT = 64000
+
+function mod.setOamLimit(limit)
+    OAM_LIMIT = limit
+end
 
 -- Render to screen what the pretend PPU knows
 function mod.renderBuffer()


### PR DESCRIPTION
- Added a new cyclic shuffle style inspired by Recca
  - To facilitate this, the `--alternating` flag has been replaced with a `--shuffle` option
- Added `--oam-limit`, which allows you to limit the size of the mock OAM
- Added `--disable-i-frame-flicker`, which disables i-frame flicker for Mega Man and bosses. Mostly for TASing.
- `-v` now has levels. Try `-vv` or `-vvv`!
- The default behavior is now `--order canonical --shuffle alternating`, which matches the game exactly frame by frame.